### PR TITLE
Add an initial english (Australia) translation

### DIFF
--- a/src/Sweetfish.cpp
+++ b/src/Sweetfish.cpp
@@ -4,11 +4,18 @@
  */
 #include "Sweetfish.h"
 #include "UI/MainWindow.h"
+#include <QTranslator>
 #include <QApplication>
 #include <QTextCodec>
 
 int main(int argc, char *argv[]) {
   QApplication app(argc, argv);
+  // hacky translator stuff I picked up off the qt tutorials https://doc.qt.io/qt-5/qtlinguist-arrowpad-example.html
+  // attempts to load a translation file for the current locale
+  QTranslator translator;
+  QString locale = QLocale::system().name();
+  translator.load(QString("sweetfish-") + locale);
+  app.installTranslator(&translator);
   //全般設定
   QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
   app.setWindowIcon(QIcon(":/icon-normal.png")); //埋め込み

--- a/src/Translations/sweetfish-en_AU.ts
+++ b/src/Translations/sweetfish-en_AU.ts
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_AU" sourcelanguage="ja_JP">
+<context>
+    <name>ImageViewer</name>
+    <message>
+        <location filename="ImageViewer.cpp" line="25"/>
+        <location filename="ImageViewer.cpp" line="185"/>
+        <source>画像の詳細 </source>
+        <translation>Image details </translation>
+    </message>
+    <message>
+        <location filename="ImageViewer.cpp" line="56"/>
+        <source>次へ(&amp;N)</source>
+        <translation>&amp;Next</translation>
+    </message>
+    <message>
+        <location filename="ImageViewer.cpp" line="57"/>
+        <source>前へ(&amp;B)</source>
+        <translation>&amp;Back</translation>
+    </message>
+    <message>
+        <location filename="ImageViewer.cpp" line="58"/>
+        <source>名前を付けて保存(&amp;S)</source>
+        <translation>&amp;Save image</translation>
+    </message>
+    <message>
+        <location filename="ImageViewer.cpp" line="59"/>
+        <source>コピー(&amp;P)</source>
+        <translation>&amp;Copy</translation>
+    </message>
+    <message>
+        <location filename="ImageViewer.cpp" line="60"/>
+        <source>閉じる(&amp;C)</source>
+        <translation>&amp;Quit</translation>
+    </message>
+    <message>
+        <location filename="ImageViewer.cpp" line="174"/>
+        <source>画像</source>
+        <translation>Image</translation>
+    </message>
+    <message>
+        <location filename="ImageViewer.cpp" line="183"/>
+        <source>名前を付けて保存</source>
+        <translation>Save as</translation>
+    </message>
+    <message>
+        <location filename="ImageViewer.cpp" line="186"/>
+        <source>画像の保存に失敗しました。</source>
+        <translation>Failed to save the image.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="MainWindow.cpp" line="84"/>
+        <source>マストドンアプリの認証を行いますか。</source>
+        <translation>Authorize with Mastodon?</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="88"/>
+        <source>マストドンアプリの認証を行わなければこのソフトウェアは使用できません。</source>
+        <translation>This software requires authenticating with Mastodon.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="123"/>
+        <source>設定(&amp;S)</source>
+        <translation>&amp;Settings</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="126"/>
+        <source>ストリーム接続(&amp;S)</source>
+        <translation>Auto-&amp;refresh</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="131"/>
+        <source>チェックされるとストリームに接続し、外されると切断します。</source>
+        <translation>Automatically gets the latest posts from your feed.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="134"/>
+        <source>終了(&amp;E)</source>
+        <translation>&amp;Quit</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="136"/>
+        <source>すべてのウィンドウを閉じ、アプリケーションを終了します。</source>
+        <translation>Closes all windows and exits the application.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="139"/>
+        <source>表示(&amp;V)</source>
+        <translation>&amp;View</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="141"/>
+        <source>ホーム(&amp;H)</source>
+        <translation>&amp;Home</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="142"/>
+        <source>通知(&amp;H)</source>
+        <translation>&amp;Notifications</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="143"/>
+        <source>リスト(&amp;L)</source>
+        <translation>&amp;Lists</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="146"/>
+        <source>ウィンドウ(&amp;W)</source>
+        <translation>&amp;Window</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="151"/>
+        <source>常に最前面に表示(&amp;A)</source>
+        <translation>&amp;Always on top</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="153"/>
+        <source>常にこのウィンドウを手前に表示します。(ウィンドウマネージャで設定できる場合はそちらで設定してください。)</source>
+        <translation>Keeps the window floating above other windows.
+If possible, set this in your window manager instead.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="158"/>
+        <source>ヘルプ(&amp;H)</source>
+        <translation>&amp;Help</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="165"/>
+        <source>バージョンやライセンスについてのダイアログを表示します。</source>
+        <translation>Displays version and license information.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="168"/>
+        <source>Qtについて(&amp;Q)</source>
+        <translation>About &amp;Qt</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="169"/>
+        <source>使用されているQtのライブラリのバージョンやライセンスについてのダイアログを表示します。</source>
+        <translation>Displays version and license information about the Qt library in use.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="226"/>
+        <source>タイムラインを更新します。</source>
+        <translation>Refresh the timeline.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="235"/>
+        <source>写真・動画を追加します。</source>
+        <translation>Upload media.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="244"/>
+        <source>トゥートを送信します。</source>
+        <translation>Send Toot.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="265"/>
+        <source>無効なドメイン名です。</source>
+        <translation>Invalid domain name.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="273"/>
+        <source>アプリケーションの登録に失敗しました。</source>
+        <translation>Failed to register the application.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="282"/>
+        <source>ブラウザの起動に失敗しました。</source>
+        <translation>Failed to open a browser.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="286"/>
+        <source>認証がキャンセルされました。</source>
+        <translation>Authentication was cancelled.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="294"/>
+        <source>アクセストークンの取得に失敗しました。</source>
+        <translation>Couldn&apos;t get an access token.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="311"/>
+        <source>ユーザ情報の取得に失敗しました。</source>
+        <translation>Failed to get user information.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="335"/>
+        <location filename="MainWindow.cpp" line="356"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="339"/>
+        <source>認証するインスタンスのドメイン名を入力してください。(https://は不要です。)
+例) netstat.app</source>
+        <translation>Enter the domain name of your instance, without the protocol specifier (ie https://).</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="360"/>
+        <source>表示されたブラウザでMastodonの認証して、表示された認証コードを入力してください。</source>
+        <translation>Please log in to Mastodon and copy the authentication code into this window.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="382"/>
+        <source>タイムラインに接続できませんでした。再接続しますか。</source>
+        <translation>Could not connect to timeline. Reconnect?</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="386"/>
+        <source>タイムラインから切断されました。再接続しますか。</source>
+        <translation>Disconnected from the timeline. Reconnect?</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="390"/>
+        <source>メモリアクセス違反が発生しました。</source>
+        <translation>A memory access violation occured.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="393"/>
+        <source>不明なエラーが発生しました。</source>
+        <translation>An unknown error occured.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="494"/>
+        <source>メディア追加</source>
+        <translation>Add media.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="495"/>
+        <source>メディア (*.png *.jpg *.gif *.bmp *.pbm *.pgm *.ppm *.xbm *.xpm *.svg)</source>
+        <translation>Media (*.png *.jpg *.gif *.bmp *.pbm *.pgm *.ppm *.xbm *.xpm *.svg)</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="510"/>
+        <source>サポートしていない画像です。</source>
+        <translation>File type not supported.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="513"/>
+        <source>ファイルサイズが大きすぎます。</source>
+        <translation>File too large.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="516"/>
+        <location filename="MainWindow.cpp" line="539"/>
+        <source>４枚以上の画像は投稿できません。</source>
+        <translation>You can only post 4 images at a time.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="620"/>
+        <location filename="MainWindow.cpp" line="628"/>
+        <source>さんが</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="621"/>
+        <source>以下のトゥートをお気に入りに登録しました。
+</source>
+        <translation>added your toot to their favourites:
+</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="623"/>
+        <location filename="MainWindow.cpp" line="631"/>
+        <source>不明</source>
+        <translation>Unknown</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="629"/>
+        <source>以下のトゥートをブーストしました。
+</source>
+        <translation>boosted the following toot:
+</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="637"/>
+        <source>さんがあなたに向けてトゥートしました。
+</source>
+        <translation>mentioned you
+</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="644"/>
+        <source>さんがあなたをフォローしました。</source>
+        <translation>followed you</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="679"/>
+        <source>トゥートに失敗しました </source>
+        <translation>Toot failed </translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="714"/>
+        <source>作業に失敗しました </source>
+        <translation>Operation failed </translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="800"/>
+        <source>画像の読み込みに失敗しました。</source>
+        <translation>Failed to load the image.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="810"/>
+        <source>アップロード中にエラーが発生しました。再試行しますか。</source>
+        <translation>Failed to upload. Try again?</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="819"/>
+        <source>アップロードの初期化作業に失敗しました。</source>
+        <translation>Failed to start the upload.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="880"/>
+        <source>について</source>
+        <translation>About</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="884"/>
+        <source>Qtを使用して製作されているMastodonクライアント。</source>
+        <translation>Sweetfish is a Mastodon client written with Qt.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="887"/>
+        <source>本ソフトウェアはQtオープンソース版のLGPLv3を選択しています。詳しくは&lt;a href=&quot;https://www.qt.io/licensing/&quot;&gt;https://www.qt.io/licensing/&lt;/a&gt;をご覧ください。</source>
+        <translation>This software has chosen to use the LGPLv3  open source version  of Qt. For details, please see &lt;a href=&quot;https://www.qt.io/licensing/&quot;&gt; https://www.qt.io/licensing/ &lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="893"/>
+        <source>License</source>
+        <translation>License</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="910"/>
+        <source>このソフトウェアについてのページを開く</source>
+        <translation>Open the Sweetfish homepage.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="923"/>
+        <source>このトゥートはすでにブーストしています。</source>
+        <translation>This toot has already been boosted.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="926"/>
+        <source>非公開のトゥートのためブーストできません。</source>
+        <translation>Can&apos;t boost a private toot.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="929"/>
+        <source>ダイレクトメッセージのためブーストできません。</source>
+        <translation>Can&apos;t boost a personal message.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="946"/>
+        <source>このトゥートはすでにお気に入りに登録しています。</source>
+        <translation>You already favourited this toot.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="950"/>
+        <source>さんのトゥートをお気に入りに登録しますか。</source>
+        <translation>Favourite this toot?</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="966"/>
+        <source>トゥートを削除しますか。</source>
+        <translation>Do you want to delete this toot?</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="984"/>
+        <source>非公開のトゥートのため引用できません。</source>
+        <translation>Cannot quote a private toot.</translation>
+    </message>
+    <message>
+        <location filename="MainWindow.cpp" line="987"/>
+        <source>ダイレクトメッセージのため引用できません。</source>
+        <translation>Cannot quote a personal message.</translation>
+    </message>
+</context>
+<context>
+    <name>TootContent</name>
+    <message>
+        <location filename="TootContent.cpp" line="84"/>
+        <location filename="TootContent.cpp" line="121"/>
+        <source>Delete(&amp;D)</source>
+        <translation>&amp;Delete</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="93"/>
+        <source>Boost(&amp;B)</source>
+        <translation>&amp;Boost</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="99"/>
+        <source>Quote Toot(&amp;Q)</source>
+        <translation>&amp;Quote</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="105"/>
+        <source>Reply(&amp;R)</source>
+        <translation>&amp;Reply</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="111"/>
+        <source>Favourite(&amp;F)</source>
+        <translation>&amp;Favourite</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="125"/>
+        <source>Open in new window(&amp;W)</source>
+        <translation>&amp;Open in new window</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="129"/>
+        <source>URL</source>
+        <translation>URL</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="144"/>
+        <source>クライアント</source>
+        <translation>Client</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="211"/>
+        <source> boosted</source>
+        <translation> boosted</translation>
+    </message>
+    <message>
+        <location filename="TootContent.cpp" line="363"/>
+        <source>トゥートの詳細 </source>
+        <translation>Toot details - </translation>
+    </message>
+</context>
+<context>
+    <name>TootInfo</name>
+    <message>
+        <location filename="TootInfo.cpp" line="86"/>
+        <source>操作</source>
+        <translation>Operation</translation>
+    </message>
+    <message>
+        <location filename="TootInfo.cpp" line="90"/>
+        <source>Delete(&amp;D)</source>
+        <translation>&amp;Delete</translation>
+    </message>
+</context>
+<context>
+    <name>VideoPlayer</name>
+    <message>
+        <location filename="VideoPlayer.cpp" line="46"/>
+        <source>動画 </source>
+        <translation>Video </translation>
+    </message>
+    <message>
+        <location filename="VideoPlayer.cpp" line="67"/>
+        <source>再生(&amp;S)</source>
+        <translation>Play (&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="VideoPlayer.cpp" line="68"/>
+        <source>一時停止(&amp;P)</source>
+        <translation>&amp;Pause</translation>
+    </message>
+    <message>
+        <location filename="VideoPlayer.cpp" line="69"/>
+        <source>最初に戻る(&amp;B)</source>
+        <translation>&amp;Rewind</translation>
+    </message>
+    <message>
+        <location filename="VideoPlayer.cpp" line="70"/>
+        <source>閉じる(&amp;C)</source>
+        <translation>&amp;Quit</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Apologies for not commenting in Japanese, but I don't speak or read it.

This PR includes a translation file (ts) for Australian english, and some extra code in /src/Sweetfish.cpp to try to load a translation for the current locale.